### PR TITLE
Fix build script 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "pack": "electron-builder --config build.json --dir",
     "dist": "npm run build && electron-builder --config build.json",
-    "build": "cat src/style.stylus.css | $(npm bin)/stylus > build/style.css",
+    "build": "mkdir -p build; cat src/style.stylus.css | $(npm bin)/stylus > build/style.css",
     "start": "npm run build && electron . "
   },
   "keywords": [],


### PR DESCRIPTION
`mkdir -p build`, so the build doesn't fail when there is no directory "build"