### PR TITLE
Escape file paths

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -57,7 +57,7 @@ function setPwd(path, image_count) {
 }
 
 function imgUrl(relpath) {
-  return 'file://' + path.join(root, relpath)
+  return 'file://' + escape(path.join(root, relpath))
 }
 
 function setImages(images) {


### PR DESCRIPTION
I store all my images in a folder called `# Pics` (so it stays at the top of alphabetic listings). Isolate is not able to display any images within that folder as `#` is a special character in URLs.

This PR escapes all file paths, which fixes the issue for me.

There was no info on contributing guidelines so I'm just sending this off. Please tell me if you want any changes Seena. 

Thanks btw, this is a really cool project! (had been thinking of doing something like this, but never actually did it)